### PR TITLE
Add example of `tofu validate` when a module requires `alias` 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,8 @@ crash.log
 crash.*.log
 
 # Exclude all .tfvars files, which are likely to contain sensitive data, such as
-# password, private keys, and other secrets. These should not be part of version 
-# control as they are data points which are potentially sensitive and subject 
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
 # to change depending on the environment.
 *.tfvars
 *.tfvars.json
@@ -32,3 +32,6 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+# Ignore .terraform.lock.hcl in modules
+infrastructure/opentofu/modules/**/.terraform.lock.hcl

--- a/infrastructure/opentofu/.terraform.lock.hcl
+++ b/infrastructure/opentofu/.terraform.lock.hcl
@@ -1,10 +1,29 @@
 # This file is maintained automatically by "tofu init".
 # Manual edits may be lost in future updates.
 
+provider "registry.opentofu.org/hashicorp/null" {
+  version     = "3.2.2"
+  constraints = "~> 3.2"
+  hashes = [
+    "h1:sU0t6ANQ4IfEwZbbBmcNeOCg2CDCViVb7L7QVfIHrCs=",
+    "zh:00e5877d19fb1c1d8c4b3536334a46a5c86f57146fd115c7b7b4b5d2bf2de86d",
+    "zh:1755c2999e73e4d73f9de670c145c9a0dc5a373802799dff06a0e9c161354163",
+    "zh:2b29d706353bc9c4edda6a2946af3322abe94372ffb421d81fa176f1e57e33be",
+    "zh:34f65259c6d2bd51582b6da536e782b181b23725782b181193b965f519fbbacd",
+    "zh:370f6eb744475926a1fa7464d82d46ad83c2e1148b4b21681b4cec4d75b97969",
+    "zh:5950bdb23b4fcc6431562d7eba3dea37844aa4220c4da2eb898ae3e4d1b64ec4",
+    "zh:8f3d5c8d4b9d497fec36953a227f80c76d37fc8431b683a23fb1c42b9cccbf8a",
+    "zh:8f6eb5e65c047bf490ad3891efecefc488503b65898d4ee106f474697ba257d7",
+    "zh:a7040eed688316fe00379574c72bb8c47dbe2638b038bb705647cbf224de8f72",
+    "zh:e561f28df04d9e51b75f33004b7767a53c45ad96e3375d86181ba1363bffbc77",
+  ]
+}
+
 provider "registry.opentofu.org/integrations/github" {
   version     = "6.0.0"
   constraints = "~> 6.0"
   hashes = [
+    "h1:C0tQYTi4xfFbv49ohtqcnUS6N3zkieMUlGgVtZa2KNg=",
     "h1:jLOsi4Qu5g5D2/n/xg/CljAKCRH9F9paiWRZtyzWR+k=",
     "zh:0d12fde69c54d358af3a45cf1610b711e1cd6a5d0be8d71c24729f28faa4a67d",
     "zh:501fd9a181bbb1f3e70c3a54463bc16974569dddd1311fdd682c3b893ebc8455",

--- a/infrastructure/opentofu/alias_issue.tf
+++ b/infrastructure/opentofu/alias_issue.tf
@@ -1,0 +1,8 @@
+module "alias_issue" {
+  source = "./modules/opentofu-skovbar-example"
+  providers = {
+    null               = null
+    null.alias         = null.root_configuration_alias
+    null.another_alias = null.root_configuration_another_alias
+  }
+}

--- a/infrastructure/opentofu/justfile
+++ b/infrastructure/opentofu/justfile
@@ -1,0 +1,12 @@
+default:
+    just --list
+
+configure:
+    tofu init
+
+validate:
+    tofu fmt -check .
+    tofu validate
+
+fix:
+    tofu fmt -recursive .

--- a/infrastructure/opentofu/modules/opentofu-skovbar-example/justfile
+++ b/infrastructure/opentofu/modules/opentofu-skovbar-example/justfile
@@ -1,0 +1,12 @@
+default:
+    just --list
+
+configure:
+    tofu init
+
+validate:
+    tofu fmt -check .
+    tofu validate
+
+fix:
+    tofu fmt -recursive .

--- a/infrastructure/opentofu/modules/opentofu-skovbar-example/main.tf
+++ b/infrastructure/opentofu/modules/opentofu-skovbar-example/main.tf
@@ -1,0 +1,10 @@
+resource "null_resource" "this" {
+}
+
+resource "null_resource" "this_alias" {
+  provider = null.alias
+}
+
+resource "null_resource" "this_another_alias" {
+  provider = null.another_alias
+}

--- a/infrastructure/opentofu/modules/opentofu-skovbar-example/versions.tf
+++ b/infrastructure/opentofu/modules/opentofu-skovbar-example/versions.tf
@@ -1,10 +1,6 @@
 terraform {
-  required_version = ">= 1.6.0, <2.0.0"
+  required_version = ">=1.6,<=2.0.0"
   required_providers {
-    github = {
-      source  = "integrations/github"
-      version = "~> 6.0"
-    }
     null = {
       source  = "hashicorp/null"
       version = "~> 3.2"

--- a/infrastructure/opentofu/providers.tf
+++ b/infrastructure/opentofu/providers.tf
@@ -6,3 +6,11 @@ provider "github" {
     pem_file        = base64decode(var.github_app_pem_file)
   }
 }
+
+provider "null" {
+  alias = "root_configuration_alias"
+}
+
+provider "null" {
+  alias = "root_configuration_another_alias"
+}


### PR DESCRIPTION
- **Update `.gitignore`**
- **Example of `tofu validate` failing with aliases**
